### PR TITLE
Define existing method in interface and move documentation from service to interface

### DIFF
--- a/src/Contracts/SodiumService.php
+++ b/src/Contracts/SodiumService.php
@@ -37,4 +37,12 @@ interface SodiumService
      * @throws DecryptException
      */
     public function decrypt(string $message, string $key = null): string;
+
+    /**
+     * Decrypt the value using a nonce or null on failure.
+     *
+     * @param string $value the value to decrypt
+     * @param string $nonce The base64 encoded nonce
+     */
+    public function decryptValueByNonce(string $value, string $nonce): ?string;
 }

--- a/src/Services/SodiumService.php
+++ b/src/Services/SodiumService.php
@@ -133,10 +133,7 @@ class SodiumService implements Contract
     }
 
     /**
-     * Decrypt the value using a nonce or null on failure.
-     *
-     * @param string $value the value to decrypt
-     * @param string $nonce The base64 encoded nonce
+     * {@inheritdoc}
      */
     public function decryptValueByNonce(string $value, string $nonce): ?string
     {


### PR DESCRIPTION
for: #9929

Cleaning up some previous changes I made.

I added a method that was already defined in the service to the service's interface to clean up a scrutinized complaint on STDCheck

