### PR TITLE
Sodium exception was caught

### DIFF
--- a/src/Contracts/SodiumService.php
+++ b/src/Contracts/SodiumService.php
@@ -8,6 +8,7 @@ use Exception;
 use Healthlabs\Sodium\Exceptions\DecryptException;
 use Healthlabs\Sodium\Exceptions\KeyNotFoundException;
 use Healthlabs\Sodium\Exceptions\MalformationException;
+use SodiumException;
 
 /**
  * Service contract that a implementation should follow.
@@ -35,6 +36,7 @@ interface SodiumService
      * @throws KeyNotFoundException
      * @throws MalformationException
      * @throws DecryptException
+     * @throws SodiumException
      */
     public function decrypt(string $message, string $key = null): string;
 

--- a/src/Services/SodiumService.php
+++ b/src/Services/SodiumService.php
@@ -10,6 +10,7 @@ use Healthlabs\Sodium\Exceptions\DecryptException;
 use Healthlabs\Sodium\Exceptions\KeyNotFoundException;
 use Healthlabs\Sodium\Exceptions\MalformationException;
 use Healthlabs\Sodium\Exceptions\NonceException;
+use SodiumException;
 
 /**
  * The service to encrypt/decrypt messages using sodium.
@@ -139,7 +140,7 @@ class SodiumService implements Contract
     {
         try {
             return $this->decrypt($nonce ? implode('.', [$nonce, $value]) : $value);
-        } catch (DecryptException | KeyNotFoundException | MalformationException $e) {
+        } catch (DecryptException | KeyNotFoundException | MalformationException | SodiumException $e) {
             return null;
         }
     }

--- a/tests/ServiceTest.php
+++ b/tests/ServiceTest.php
@@ -190,4 +190,17 @@ class ServiceTest extends TestCase
         $decryptedValue = $service->decryptValueByNonce($encryptedValue, $nonce);
         $this->assertSame($originalValue, $decryptedValue);
     }
+
+    /**
+     * Test that service can not decrypt a wrong encrypted value with a nonce.
+     */
+    public function testCanNotDecryptAwrongEncryptedValueByNonce()
+    {
+        $key = 'test_key';
+        $nonce = 'abcdefghijklmnopqrstuvwxyz123456';
+        $wrongEncryptedValue = 'testing';
+        $service = new SodiumService($key);
+        $decryptedValue = $service->decryptValueByNonce($wrongEncryptedValue, $nonce);
+        $this->assertNull($decryptedValue);
+    }
 }


### PR DESCRIPTION
**Description:**

This solution caught every `\SodiumExeption` thrown by the ext-sodium standard library.

**Expected Behavior:**

When there is a  malformed encrypted value, `SodiumService` must caught the proper exception and return a null value.

**Actual Result:**

When there is a malformed encrypted value, a `\SodiumExeption`  is thrown with the message `invalid base64 string`

**Cause:**

For this issue, it is caused because a malformed encrypted value, a string that has not a `.` on its body.

**Solution:**

Catch the common exception `\SodiumExeption` and return a null value.


